### PR TITLE
Accept `JetBrains s.r.o` as a JetBrains vendor synonym

### DIFF
--- a/src/main/java/io/foojay/api/distribution/JetBrains.java
+++ b/src/main/java/io/foojay/api/distribution/JetBrains.java
@@ -128,7 +128,7 @@ public class JetBrains implements Distribution {
     @Override public String getOfficialUri() { return OFFICIAL_URI; }
 
     @Override public List<String> getSynonyms() {
-        return List.of("jetbrains", "JetBrains", "JETBRAINS");
+        return List.of("jetbrains", "JetBrains", "JETBRAINS", "JetBrains s.r.o");
     }
 
     @Override public List<Semver> getVersions() {

--- a/src/main/java/io/foojay/api/pkg/Distro.java
+++ b/src/main/java/io/foojay/api/pkg/Distro.java
@@ -258,6 +258,7 @@ public enum Distro implements Api {
             case "jetbrains":
             case "JetBrains":
             case "JETBRAINS":
+            case "JetBrains s.r.o":
                 return JETBRAINS;
             case "liberica":
             case "LIBERICA":


### PR DESCRIPTION
Accept `JetBrains s.r.o` as a JetBrains vendor synonym. See: gradle/gradle#26014