### PR TITLE
Use code block format for REST endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,12 +65,14 @@ Please find more information here:
 
 ---
 ### REST endpoints 
+```
 /api.foojay.io/disco/v3.0/major_versions
 /api.foojay.io/disco/v3.0/distributions
 /api.foojay.io/disco/v3.0/packages
 /api.foojay.io/disco/v3.0/packages/jdks
 /api.foojay.io/disco/v3.0/packages/jres
 /api.foojay.io/disco/v3.0/ids
+```
 
 ---
 ### Endpoint: major_versions


### PR DESCRIPTION
The current links are all in one line.

<img width="876" alt="image" src="https://github.com/foojayio/discoapi/assets/10363352/77589e71-ebeb-455d-9721-09035cefa671">
