### PR TITLE
Both of jdk and jre package types should be concerned for Kona

### DIFF
--- a/src/main/java/io/foojay/api/distribution/Kona.java
+++ b/src/main/java/io/foojay/api/distribution/Kona.java
@@ -61,7 +61,7 @@ import static eu.hansolo.jdktools.OperatingSystem.LINUX;
 import static eu.hansolo.jdktools.OperatingSystem.MACOS;
 import static eu.hansolo.jdktools.OperatingSystem.WINDOWS;
 import static eu.hansolo.jdktools.PackageType.JDK;
-
+import static eu.hansolo.jdktools.PackageType.JRE;
 
 public class Kona implements Distribution {
     private static final Logger LOGGER = LoggerFactory.getLogger(Kona.class);
@@ -264,7 +264,11 @@ public class Kona implements Distribution {
                 pkg.setDistributionVersion(vNumber);
                 pkg.setJdkVersion(new MajorVersion(vNumber.getFeature().getAsInt()));
                 pkg.setTermOfSupport(Helper.getTermOfSupport(vNumber));
-                pkg.setPackageType(JDK);
+                if (filename.contains("_jre")) {
+                    pkg.setPackageType(JRE);
+                } else {
+                    pkg.setPackageType(JDK);
+                }
                 pkg.setReleaseStatus(filename.contains("-ea") ? ReleaseStatus.EA : ReleaseStatus.GA);
 
                 if (filename.contains("_fiber")) { pkg.setFeatures(List.of(Feature.KONA_FIBER)); }


### PR DESCRIPTION
If a Kona file name contains `_jre`, like `TencentKona8.0.19.b1_jre_linux-x86_64_8u422.tar.gz`, the package type should be `jre`, but not `jdk`.